### PR TITLE
remove unnecessary variable update in todo-item on-change hook

### DIFF
--- a/src/app/components/todo-item/todo-item.component.ts
+++ b/src/app/components/todo-item/todo-item.component.ts
@@ -33,9 +33,7 @@ export class TodoItemComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(): void {
-    this.editedTodo = { ...this.todo };
-  }
+  ngOnChanges(): void { }
 
   complete(): void {
     this.update({ ...this.todo, completed: true });


### PR DESCRIPTION
You can remove this line since we update this on line 65:     this.editedTodo = { ...this.todo };